### PR TITLE
Add Gemini-based Telegram reminder agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# ai-gita
+# Telegram Reminder Agent
+
+This repository contains a simple example of using LangChain with Google's
+Gemini model to parse natural language reminder requests and send them via a
+Telegram bot.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set environment variables:
+   - `TELEGRAM_BOT_TOKEN` – token for your Telegram bot.
+   - `GOOGLE_API_KEY` – API key for Gemini.
+
+## Run
+
+```bash
+python telegram_reminder_agent.py
+```
+
+Send the bot a message such as "Remind me to take drugs tomorrow at 2pm" and it
+will schedule a reminder and send a message at the specified time.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+langchain
+langchain-google-genai
+python-telegram-bot

--- a/telegram_reminder_agent.py
+++ b/telegram_reminder_agent.py
@@ -1,0 +1,96 @@
+"""Telegram reminder bot using LangChain with Gemini API.
+
+This bot listens to messages on Telegram and uses a Gemini-powered
+LangChain chain to parse reminder requests. When a user sends a message like
+"Remind me to take drugs tomorrow at 2pm", the bot schedules a reminder and
+sends the user a Telegram message at the requested time.
+
+Environment variables required:
+- TELEGRAM_BOT_TOKEN: token for your Telegram bot.
+- GOOGLE_API_KEY: API key for the Google Gemini service.
+
+Run with:
+    python telegram_reminder_agent.py
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain.output_parsers import ResponseSchema, StructuredOutputParser
+from langchain.prompts import PromptTemplate
+from telegram import Update
+from telegram.ext import (
+    ApplicationBuilder,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+# Define how the LLM should format its response
+RESPONSE_SCHEMAS = [
+    ResponseSchema(name="task", description="task to remind the user about"),
+    ResponseSchema(
+        name="time",
+        description="ISO 8601 timestamp for when the reminder should occur (in UTC)",
+    ),
+]
+OUTPUT_PARSER = StructuredOutputParser.from_response_schemas(RESPONSE_SCHEMAS)
+FORMAT_INSTRUCTIONS = OUTPUT_PARSER.get_format_instructions()
+
+PROMPT = PromptTemplate(
+    template=(
+        "Extract a reminder from the message.\n"
+        "{format_instructions}\n"
+        "Message: {message}"
+    ),
+    input_variables=["message"],
+    partial_variables={"format_instructions": FORMAT_INSTRUCTIONS},
+)
+
+LLM = ChatGoogleGenerativeAI(
+    model="gemini-pro", google_api_key=os.environ.get("GOOGLE_API_KEY", "")
+)
+
+
+async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle incoming messages and schedule reminders."""
+    user_text = update.message.text
+
+    chain = PROMPT | LLM | OUTPUT_PARSER
+    parsed = chain.invoke({"message": user_text})
+    task = parsed["task"]
+    time_str = parsed["time"]
+    remind_time = datetime.fromisoformat(time_str)
+    if remind_time.tzinfo is None:
+        remind_time = remind_time.replace(tzinfo=timezone.utc)
+
+    chat_id = update.effective_chat.id
+    delay = remind_time - datetime.now(timezone.utc)
+    context.job_queue.run_once(send_reminder, when=delay, chat_id=chat_id, data=task)
+
+    await update.message.reply_text(
+        f"Got it! I'll remind you to {task} at {remind_time.isoformat()}"
+    )
+
+
+async def send_reminder(context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send the reminder message."""
+    job = context.job
+    await context.bot.send_message(job.chat_id, text=f"Reminder: {job.data}")
+
+
+def main() -> None:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN environment variable not set")
+
+    application = ApplicationBuilder().token(token).build()
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `telegram_reminder_agent.py` that uses LangChain with Gemini to schedule reminders over Telegram
- document setup and usage in README
- include minimal requirements file

## Testing
- `python -m py_compile telegram_reminder_agent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4706064e48330b2ea96821c73fd5b